### PR TITLE
Feat/set event id transform

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,10 @@ This transform receives a standard debezium record and transforms two Float/Doub
 a format that is accepted in ElasticSearch as geo_point(format="lat,lng").
 The user has to pass the name of the streamed database's latitude and longitude fields and
 also the name of the field he wants to output to.
+
+## SetEventId
+
+This transform adds a unique, UUID-generated field to represent a given event.
+Its goal is supporting the automatic generation of unique ids for cases where they are not available in Debezium's source
+and an outbox pattern is not being actively utilized. The name of the field may be passed as a configuration
+in the Debezium source properties as `field`.

--- a/README.md
+++ b/README.md
@@ -35,4 +35,4 @@ also the name of the field he wants to output to.
 This transform adds a unique, UUID-generated field to represent a given event.
 Its goal is supporting the automatic generation of unique ids for cases where they are not available in Debezium's source
 and an outbox pattern is not being actively utilized. The name of the field may be passed as a configuration
-in the Debezium source properties as `field`.
+in the Debezium source properties as `field`. If the given name already exists, the SMT ignores the given record.

--- a/src/main/java/com/inloco/debezium/transforms/SetEventId.java
+++ b/src/main/java/com/inloco/debezium/transforms/SetEventId.java
@@ -27,7 +27,7 @@ public class SetEventId implements Transformation {
               ConfigDef.Type.STRING,
               ConfigDef.NO_DEFAULT_VALUE,
               ConfigDef.Importance.HIGH,
-              "The name of the new field which for the event id.");
+              "The name of the new field for the event id.");
 
   private String eventIdField;
   private Cache<Schema, Schema> schemaUpdateCache;

--- a/src/main/java/com/inloco/debezium/transforms/SetEventId.java
+++ b/src/main/java/com/inloco/debezium/transforms/SetEventId.java
@@ -19,9 +19,8 @@ import org.apache.kafka.connect.transforms.util.SchemaUtil;
 
 public class SetEventId implements Transformation {
   private static final String PURPOSE = "Access values to insert new event id field";
-  protected static final String DEFAULT_EVENT_ID_FIELD = "event_id";
   protected static final String EVENT_FIELD_CONFIG = "field";
-  private static final ConfigDef CONFIG_DEF =
+  protected static final ConfigDef CONFIG_DEF =
       new ConfigDef()
           .define(
               EVENT_FIELD_CONFIG,

--- a/src/main/java/com/inloco/debezium/transforms/SetEventId.java
+++ b/src/main/java/com/inloco/debezium/transforms/SetEventId.java
@@ -1,0 +1,96 @@
+package com.inloco.debezium.transforms;
+
+import static org.apache.kafka.connect.transforms.util.Requirements.requireStruct;
+
+import java.util.Map;
+import java.util.UUID;
+import org.apache.kafka.common.cache.Cache;
+import org.apache.kafka.common.cache.LRUCache;
+import org.apache.kafka.common.cache.SynchronizedCache;
+import org.apache.kafka.common.config.AbstractConfig;
+import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.connect.connector.ConnectRecord;
+import org.apache.kafka.connect.data.Field;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.transforms.Transformation;
+import org.apache.kafka.connect.transforms.util.SchemaUtil;
+
+public class SetEventId implements Transformation {
+  private static final String PURPOSE = "Access values to insert new event id field";
+  protected static final String DEFAULT_EVENT_ID_FIELD = "event_id";
+  protected static final String EVENT_FIELD_CONFIG = "field";
+  private static final ConfigDef CONFIG_DEF =
+      new ConfigDef()
+          .define(
+              EVENT_FIELD_CONFIG,
+              ConfigDef.Type.STRING,
+              ConfigDef.NO_DEFAULT_VALUE,
+              ConfigDef.Importance.HIGH,
+              "The name of the new field which for the event id.");
+
+  private String eventIdField;
+  private Cache<Schema, Schema> schemaUpdateCache;
+
+  @Override
+  public ConnectRecord apply(ConnectRecord record) {
+    final Struct recordValue = requireStruct(record.value(), PURPOSE);
+    if (recordValue.schema().field(eventIdField) != null) return record;
+    final Schema updatedRecordSchema = updateSchema(recordValue);
+    final Struct updatedRecordValue = addEventId(recordValue, updatedRecordSchema);
+    return record.newRecord(
+        record.topic(),
+        record.kafkaPartition(),
+        record.keySchema(),
+        record.key(),
+        updatedRecordSchema,
+        updatedRecordValue,
+        record.timestamp());
+  }
+
+  private Schema updateSchema(Struct recordValue) {
+    Schema updatedSchema = schemaUpdateCache.get(recordValue.schema());
+    if (updatedSchema == null) {
+      updatedSchema = makeUpdatedSchema(recordValue.schema());
+      schemaUpdateCache.put(recordValue.schema(), updatedSchema);
+    }
+    return updatedSchema;
+  }
+
+  private Schema makeUpdatedSchema(Schema schema) {
+    final SchemaBuilder builder = SchemaUtil.copySchemaBasics(schema, SchemaBuilder.struct());
+    for (Field field : schema.fields()) {
+      builder.field(field.name(), field.schema());
+    }
+    builder.field(eventIdField, Schema.OPTIONAL_STRING_SCHEMA);
+    return builder.build();
+  }
+
+  private Struct addEventId(Struct recordValue, Schema updatedSchema) {
+    final Struct updatedRecordValue = new Struct(updatedSchema);
+    for (Field field : updatedSchema.fields()) {
+      final Object fieldValue =
+          field.name().equals(eventIdField)
+              ? UUID.randomUUID().toString()
+              : recordValue.get(field.name());
+      updatedRecordValue.put(field.name(), fieldValue);
+    }
+    return updatedRecordValue;
+  }
+
+  @Override
+  public ConfigDef config() {
+    return CONFIG_DEF;
+  }
+
+  @Override
+  public void close() {}
+
+  @Override
+  public void configure(Map<String, ?> configs) {
+    AbstractConfig config = new AbstractConfig(CONFIG_DEF, configs);
+    eventIdField = config.getString(EVENT_FIELD_CONFIG);
+    schemaUpdateCache = new SynchronizedCache<>(new LRUCache<>(16));
+  }
+}

--- a/src/test/java/com/inloco/debezium/transforms/SetEventIdTest.java
+++ b/src/test/java/com/inloco/debezium/transforms/SetEventIdTest.java
@@ -1,0 +1,90 @@
+package com.inloco.debezium.transforms;
+
+import static org.apache.kafka.connect.transforms.util.Requirements.requireStruct;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.kafka.connect.connector.ConnectRecord;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.sink.SinkRecord;
+import org.junit.jupiter.api.Test;
+
+class SetEventIdTest {
+  @Test
+  void testSetEventId_withAllConfigs() {
+    Schema schema = createValueSchema();
+    Struct value = populateInnerFields(schema);
+    SinkRecord record = new SinkRecord("", 0, null, null, schema, value, 0);
+
+    String eventIdField = "event_id_test";
+    Map<String, Object> configurations = new HashMap<>();
+    configurations.put(SetEventId.EVENT_FIELD_CONFIG, eventIdField);
+    SetEventId transform = new SetEventId();
+    transform.configure(configurations);
+
+    ConnectRecord transformedRecord = transform.apply(record);
+    assertThat(requireStruct(transformedRecord.value(), "testing").getString(eventIdField))
+        .isNotNull();
+  }
+
+  @Test
+  void testSetEventId_withAlreadyExistingEventId() {
+    String eventIdField = "event_id_test";
+    Schema schema = createValueSchemaWithEventId(eventIdField);
+    Struct value = populateInnerFieldsWithPreExistingEventId(schema, eventIdField);
+    SinkRecord record = new SinkRecord("", 0, null, null, schema, value, 0);
+
+    Map<String, Object> configurations = new HashMap<>();
+    configurations.put(SetEventId.EVENT_FIELD_CONFIG, eventIdField);
+    SetEventId transform = new SetEventId();
+    transform.configure(configurations);
+
+    ConnectRecord transformedRecord = transform.apply(record);
+    assertThat(transformedRecord).isEqualTo(record);
+  }
+
+  private Schema createValueSchema() {
+    return SchemaBuilder.struct()
+        .name("record")
+        .field("after", createInnerSchemaWithoutEventId("after"))
+        .field("before", createInnerSchemaWithoutEventId("before"))
+        .build();
+  }
+
+  private Schema createValueSchemaWithEventId(String eventIdField) {
+    return SchemaBuilder.struct()
+        .name("record")
+        .field(eventIdField, Schema.OPTIONAL_STRING_SCHEMA)
+        .build();
+  }
+
+  private Schema createInnerSchemaWithoutEventId(String name) {
+    return SchemaBuilder.struct()
+        .optional()
+        .name(name)
+        .field("id", Schema.OPTIONAL_STRING_SCHEMA)
+        .field("placeholderA", Schema.OPTIONAL_BOOLEAN_SCHEMA)
+        .field("placeholderB", Schema.OPTIONAL_BOOLEAN_SCHEMA)
+        .build();
+  }
+
+  private static Struct populateInnerFields(Schema schema) {
+    Struct struct = new Struct(schema.field("after").schema());
+    struct.put("id", "id1");
+    struct.put("placeholderA", true);
+    struct.put("placeholderB", false);
+    Struct field = new Struct(schema);
+    field.put("after", struct);
+    return field;
+  }
+
+  private static Struct populateInnerFieldsWithPreExistingEventId(
+      Schema schema, String eventIdField) {
+    Struct struct = new Struct(schema);
+    struct.put(eventIdField, "fixed_event_id");
+    return struct;
+  }
+}


### PR DESCRIPTION
This PR adds a new SMT which inserts an event id field, chosen by the user, to the record's top-level schema.

The goal behind this change is supporting the automatic generation of unique ids for cases where they are not available in Debezium's source and an outbox pattern is not being actively utilized.

This code is heavily based on the default Kafka Connect transform `ReplaceField`, as seen [here](https://github.com/apache/kafka/blob/trunk/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/ReplaceField.java).