### PR TITLE
Feat/set before after name

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,3 +36,16 @@ This transform adds a unique, UUID-generated field to represent a given event.
 Its goal is supporting the automatic generation of unique ids for cases where they are not available in Debezium's source
 and an outbox pattern is not being actively utilized. The name of the field may be passed as a configuration
 in the Debezium source properties as `field`. If the given name already exists, the SMT ignores the given record.
+
+## SetBeforeAndAfterName
+
+This transform modifies the `namespace` and `name` fields for the `before` and `after` Debezium schemata.
+
+Its usefulness lies in the fact that the default `SetSchemaMetadata` transform provided by Kafka Connect
+does not account for inner values, and Debezium itself does not seem to offer an alternative to that.
+This make it so the `before` and `after` namespaces are always set to the database configuration values
+(e.g. database name, namespace, and table) with the `Value` name.
+
+The transform's only configuration value is the new `name` for the schemata, which may be composed of a
+dot-separated string that will in turn be converted as a package-like structure to generate the namespace and name for the records,
+i.e. `com.my.app` turns into `{ "namespace": "com.my", "name": "app" }`.

--- a/src/main/java/com/inloco/debezium/transforms/SetBeforeAndAfterName.java
+++ b/src/main/java/com/inloco/debezium/transforms/SetBeforeAndAfterName.java
@@ -1,0 +1,156 @@
+package com.inloco.debezium.transforms;
+
+import static org.apache.kafka.connect.transforms.util.Requirements.requireStruct;
+
+import java.util.Map;
+import org.apache.kafka.common.cache.Cache;
+import org.apache.kafka.common.cache.LRUCache;
+import org.apache.kafka.common.cache.SynchronizedCache;
+import org.apache.kafka.common.config.AbstractConfig;
+import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.connect.connector.ConnectRecord;
+import org.apache.kafka.connect.data.Field;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.transforms.Transformation;
+import org.apache.kafka.connect.transforms.util.SchemaUtil;
+
+public class SetBeforeAndAfterName implements Transformation {
+  private static final String PURPOSE = "Access values to modify namespace";
+  private static final String BEFORE_FIELD_NAME = "before";
+  private static final String AFTER_FIELD_NAME = "after";
+
+  protected static final String NEW_NAME_CONFIG = "name";
+  protected static final ConfigDef CONFIG_DEF =
+      new ConfigDef()
+          .define(
+              NEW_NAME_CONFIG,
+              ConfigDef.Type.STRING,
+              ConfigDef.NO_DEFAULT_VALUE,
+              ConfigDef.Importance.HIGH,
+              "The new name for the internal records in the before and after schemas.");
+
+  private String newName;
+  private Cache<Schema, Schema> schemaUpdateCache;
+
+  @Override
+  public ConnectRecord apply(ConnectRecord record) {
+    final Struct recordValue = requireStruct(record.value(), PURPOSE);
+    Struct beforeValue = recordValue.getStruct(BEFORE_FIELD_NAME);
+    Struct afterValue = recordValue.getStruct(AFTER_FIELD_NAME);
+    if (beforeValue == null && afterValue == null) return record;
+
+    Schema updatedBeforeSchema = updateSchema(beforeValue);
+    Struct updatedBeforeValue = copyValues(beforeValue, updatedBeforeSchema);
+
+    Schema updatedAfterSchema = updateSchema(afterValue);
+    Struct updatedAfterValue = copyValues(afterValue, updatedAfterSchema);
+    Schema updatedRecordSchema =
+        replaceBeforeAndAfterSchemata(
+            record.valueSchema(), updatedBeforeSchema, updatedAfterSchema);
+    Struct updatedRecordValue =
+        replaceBeforeAndAfterValues(
+            record, updatedRecordSchema, updatedBeforeValue, updatedAfterValue);
+    return record.newRecord(
+        record.topic(),
+        record.kafkaPartition(),
+        record.keySchema(),
+        record.key(),
+        updatedRecordSchema,
+        updatedRecordValue,
+        record.timestamp());
+  }
+
+  private Schema updateSchema(Struct recordValue) {
+    if (recordValue == null) return null;
+    Schema updatedSchema = schemaUpdateCache.get(recordValue.schema());
+    if (updatedSchema == null) {
+      updatedSchema = makeUpdatedSchema(recordValue.schema());
+      schemaUpdateCache.put(recordValue.schema(), updatedSchema);
+    }
+    return updatedSchema;
+  }
+
+  private Schema makeUpdatedSchema(Schema schema) {
+    final SchemaBuilder builder = copyBasicsSchemaWithoutName(schema, SchemaBuilder.struct());
+    builder.name(newName);
+    for (Field field : schema.fields()) {
+      builder.field(field.name(), field.schema());
+    }
+    return builder.build();
+  }
+
+  private Struct copyValues(Struct recordValue, Schema updatedSchema) {
+    if (recordValue == null) return null;
+    final Struct updatedRecordValue = new Struct(updatedSchema);
+    for (Field field : updatedRecordValue.schema().fields()) {
+      updatedRecordValue.put(field.name(), recordValue.get(field));
+    }
+    return updatedRecordValue;
+  }
+
+  private Schema replaceBeforeAndAfterSchemata(
+      Schema schema, Schema beforeSchemaReplacement, Schema afterSchemaReplacement) {
+    final SchemaBuilder builder = SchemaUtil.copySchemaBasics(schema, SchemaBuilder.struct());
+    for (Field field : schema.fields()) {
+      if (!field.name().equals(AFTER_FIELD_NAME) && !field.name().equals(BEFORE_FIELD_NAME)) {
+        builder.field(field.name(), field.schema());
+      }
+    }
+    if (beforeSchemaReplacement != null) {
+      builder.field(BEFORE_FIELD_NAME, beforeSchemaReplacement);
+    }
+    if (afterSchemaReplacement != null) {
+      builder.field(AFTER_FIELD_NAME, afterSchemaReplacement);
+    }
+    return builder.build();
+  }
+
+  private Struct replaceBeforeAndAfterValues(
+      ConnectRecord record,
+      Schema updatedSchema,
+      Struct beforeValueReplacement,
+      Struct afterValueReplacement) {
+    final Struct updatedRecordValue = new Struct(updatedSchema);
+
+    for (Field field : record.valueSchema().fields()) {
+      if (!field.name().equals(AFTER_FIELD_NAME) && !field.name().equals(BEFORE_FIELD_NAME)) {
+        updatedRecordValue.put(field.name(), ((Struct) record.value()).get(field));
+      }
+    }
+    if (beforeValueReplacement != null) {
+      updatedRecordValue.put(BEFORE_FIELD_NAME, beforeValueReplacement);
+    }
+    if (afterValueReplacement != null) {
+      updatedRecordValue.put(AFTER_FIELD_NAME, afterValueReplacement);
+    }
+    return updatedRecordValue;
+  }
+
+  private SchemaBuilder copyBasicsSchemaWithoutName(Schema source, SchemaBuilder builder) {
+    builder.version(source.version());
+    builder.doc(source.doc());
+
+    final Map<String, String> params = source.parameters();
+    if (params != null) {
+      builder.parameters(params);
+    }
+    return builder;
+  }
+
+  @Override
+  public ConfigDef config() {
+    return CONFIG_DEF;
+  }
+
+  @Override
+  public void close() {}
+
+  @Override
+  public void configure(Map<String, ?> configs) {
+    AbstractConfig config = new AbstractConfig(CONFIG_DEF, configs);
+    newName = config.getString(NEW_NAME_CONFIG);
+    schemaUpdateCache = new SynchronizedCache<>(new LRUCache<>(16));
+  }
+}

--- a/src/test/java/com/inloco/debezium/transforms/SetBeforeAndAfterNameTest.java
+++ b/src/test/java/com/inloco/debezium/transforms/SetBeforeAndAfterNameTest.java
@@ -53,6 +53,7 @@ class SetBeforeAndAfterNameTest {
     ConnectRecord transformedRecord = transform.apply(record);
     Struct transformedRecordValue = requireStruct(transformedRecord.value(), "testing");
     assertThat(transformedRecordValue.getStruct("after").schema().name()).isEqualTo(newName);
+    assertThat(transformedRecord.valueSchema().field("before")).isNotNull();
     assertThat(transformedRecordValue.schema().name()).isEqualTo(ROOT_LEVEL_NAME);
   }
 
@@ -71,6 +72,7 @@ class SetBeforeAndAfterNameTest {
     ConnectRecord transformedRecord = transform.apply(record);
     Struct transformedRecordValue = requireStruct(transformedRecord.value(), "testing");
     assertThat(transformedRecordValue.getStruct("before").schema().name()).isEqualTo(newName);
+    assertThat(transformedRecord.valueSchema().field("after")).isNotNull();
     assertThat(transformedRecordValue.schema().name()).isEqualTo(ROOT_LEVEL_NAME);
   }
 

--- a/src/test/java/com/inloco/debezium/transforms/SetBeforeAndAfterNameTest.java
+++ b/src/test/java/com/inloco/debezium/transforms/SetBeforeAndAfterNameTest.java
@@ -54,6 +54,7 @@ class SetBeforeAndAfterNameTest {
     Struct transformedRecordValue = requireStruct(transformedRecord.value(), "testing");
     assertThat(transformedRecordValue.getStruct("after").schema().name()).isEqualTo(newName);
     assertThat(transformedRecord.valueSchema().field("before")).isNotNull();
+    assertThat(transformedRecord.valueSchema().field("before").schema().name()).isEqualTo(newName);
     assertThat(transformedRecordValue.schema().name()).isEqualTo(ROOT_LEVEL_NAME);
   }
 
@@ -73,6 +74,7 @@ class SetBeforeAndAfterNameTest {
     Struct transformedRecordValue = requireStruct(transformedRecord.value(), "testing");
     assertThat(transformedRecordValue.getStruct("before").schema().name()).isEqualTo(newName);
     assertThat(transformedRecord.valueSchema().field("after")).isNotNull();
+    assertThat(transformedRecord.valueSchema().field("after").schema().name()).isEqualTo(newName);
     assertThat(transformedRecordValue.schema().name()).isEqualTo(ROOT_LEVEL_NAME);
   }
 
@@ -89,7 +91,12 @@ class SetBeforeAndAfterNameTest {
     transform.configure(configurations);
 
     ConnectRecord transformedRecord = transform.apply(record);
-    assertThat(transformedRecord).isEqualTo(record);
+    Struct transformedRecordValue = requireStruct(transformedRecord.value(), "testing");
+    assertThat(transformedRecord.valueSchema().field("before")).isNotNull();
+    assertThat(transformedRecord.valueSchema().field("before").schema().name()).isEqualTo(newName);
+    assertThat(transformedRecord.valueSchema().field("after")).isNotNull();
+    assertThat(transformedRecord.valueSchema().field("after").schema().name()).isEqualTo(newName);
+    assertThat(transformedRecordValue.schema().name()).isEqualTo(ROOT_LEVEL_NAME);
   }
 
   private Schema createValueSchema() {

--- a/src/test/java/com/inloco/debezium/transforms/SetBeforeAndAfterNameTest.java
+++ b/src/test/java/com/inloco/debezium/transforms/SetBeforeAndAfterNameTest.java
@@ -1,0 +1,71 @@
+package com.inloco.debezium.transforms;
+
+import static org.apache.kafka.connect.transforms.util.Requirements.requireStruct;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.kafka.connect.connector.ConnectRecord;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.sink.SinkRecord;
+import org.junit.jupiter.api.Test;
+
+class SetBeforeAndAfterNameTest {
+  private static final String ROOT_LEVEL_NAME = "com.my.app";
+  private static final String INNER_NAME_WITH_NAMESPACE = "db.namespace.table.Value";
+
+  @Test
+  void testSetEventId_withAllConfigs() {
+    Schema schema = createValueSchema();
+    Struct value = populateInnerFields(schema);
+    SinkRecord record = new SinkRecord("", 0, null, null, schema, value, 0);
+
+    String newName = "com.my.app.internal.Value";
+    Map<String, Object> configurations = new HashMap<>();
+    configurations.put(SetBeforeAndAfterName.NEW_NAME_CONFIG, newName);
+    SetBeforeAndAfterName transform = new SetBeforeAndAfterName();
+    transform.configure(configurations);
+
+    ConnectRecord transformedRecord = transform.apply(record);
+    Struct transformedRecordValue = requireStruct(transformedRecord.value(), "testing");
+    assertThat(transformedRecordValue.getStruct("before").schema().name()).isEqualTo(newName);
+    assertThat(transformedRecordValue.getStruct("after").schema().name()).isEqualTo(newName);
+    assertThat(transformedRecordValue.schema().name()).isEqualTo(ROOT_LEVEL_NAME);
+  }
+
+  private Schema createValueSchema() {
+    return SchemaBuilder.struct()
+        .name(ROOT_LEVEL_NAME)
+        .field("after", createInnerSchema())
+        .field("before", createInnerSchema())
+        .build();
+  }
+
+  private Schema createInnerSchema() {
+    return SchemaBuilder.struct()
+        .optional()
+        .name(INNER_NAME_WITH_NAMESPACE)
+        .field("id", Schema.OPTIONAL_STRING_SCHEMA)
+        .field("placeholderA", Schema.OPTIONAL_BOOLEAN_SCHEMA)
+        .field("placeholderB", Schema.OPTIONAL_BOOLEAN_SCHEMA)
+        .build();
+  }
+
+  private static Struct populateInnerFields(Schema schema) {
+    Struct beforeValue = populateInnerField(schema, "before");
+    Struct afterValue = populateInnerField(schema, "after");
+    Struct outerStruct = new Struct(schema);
+    outerStruct.put("before", beforeValue);
+    outerStruct.put("after", afterValue);
+    return outerStruct;
+  }
+
+  private static Struct populateInnerField(Schema schema, String field) {
+    Struct struct = new Struct(schema.field(field).schema());
+    struct.put("placeholderA", true);
+    struct.put("placeholderB", false);
+    return struct;
+  }
+}


### PR DESCRIPTION
This PR introduces a new transform, named `SetBeforeAndAfterName`, which modifies the names for the inner `before` and `after` Debezium schemata.

As per the introduced documentation:

```
Its usefulness lies in the fact that the default `SetSchemaMetadata` transform provided by Kafka Connect
does not account for inner values, and Debezium itself does not seem to offer an alternative to that.
This make it so the `before` and `after` namespaces are always set to the database configuration values
(e.g. database name, namespace, and table) with the `Value` name.
```