### PR TITLE
Fix/fixes smts that didnt account for null messages

### DIFF
--- a/src/main/java/com/inloco/debezium/transforms/SetBeforeAndAfterName.java
+++ b/src/main/java/com/inloco/debezium/transforms/SetBeforeAndAfterName.java
@@ -36,6 +36,7 @@ public class SetBeforeAndAfterName implements Transformation {
 
   @Override
   public ConnectRecord apply(ConnectRecord record) {
+    if(record == null) return record;
     Schema beforeSchema = record.valueSchema().field(BEFORE_FIELD_NAME).schema();
     Schema afterSchema = record.valueSchema().field(AFTER_FIELD_NAME).schema();
     if (beforeSchema == null || afterSchema == null) return record;

--- a/src/main/java/com/inloco/debezium/transforms/SetBeforeAndAfterName.java
+++ b/src/main/java/com/inloco/debezium/transforms/SetBeforeAndAfterName.java
@@ -36,7 +36,7 @@ public class SetBeforeAndAfterName implements Transformation {
 
   @Override
   public ConnectRecord apply(ConnectRecord record) {
-    if (record == null) return record;
+    if (record == null || record.valueSchema() == null) return record;
     Schema beforeSchema = record.valueSchema().field(BEFORE_FIELD_NAME).schema();
     Schema afterSchema = record.valueSchema().field(AFTER_FIELD_NAME).schema();
     if (beforeSchema == null || afterSchema == null) return record;

--- a/src/main/java/com/inloco/debezium/transforms/SetBeforeAndAfterName.java
+++ b/src/main/java/com/inloco/debezium/transforms/SetBeforeAndAfterName.java
@@ -37,6 +37,9 @@ public class SetBeforeAndAfterName implements Transformation {
   @Override
   public ConnectRecord apply(ConnectRecord record) {
     if (record == null || record.valueSchema() == null) return record;
+    Field beforeField = record.valueSchema().field(BEFORE_FIELD_NAME);
+    Field afterField = record.valueSchema().field(AFTER_FIELD_NAME);
+    if(beforeField == null || afterField == null) return record;
     Schema beforeSchema = record.valueSchema().field(BEFORE_FIELD_NAME).schema();
     Schema afterSchema = record.valueSchema().field(AFTER_FIELD_NAME).schema();
     if (beforeSchema == null || afterSchema == null) return record;

--- a/src/main/java/com/inloco/debezium/transforms/SetBeforeAndAfterName.java
+++ b/src/main/java/com/inloco/debezium/transforms/SetBeforeAndAfterName.java
@@ -37,11 +37,15 @@ public class SetBeforeAndAfterName implements Transformation {
   @Override
   public ConnectRecord apply(ConnectRecord record) {
     if (record == null || record.valueSchema() == null) return record;
+
     Field beforeField = record.valueSchema().field(BEFORE_FIELD_NAME);
     Field afterField = record.valueSchema().field(AFTER_FIELD_NAME);
-    if(beforeField == null || afterField == null) return record;
-    Schema beforeSchema = record.valueSchema().field(BEFORE_FIELD_NAME).schema();
-    Schema afterSchema = record.valueSchema().field(AFTER_FIELD_NAME).schema();
+
+    if (beforeField == null || afterField == null) return record;
+
+    Schema beforeSchema = beforeField.schema();
+    Schema afterSchema = afterField.schema();
+
     if (beforeSchema == null || afterSchema == null) return record;
 
     Schema updatedBeforeSchema = updateSchema(beforeSchema);

--- a/src/main/java/com/inloco/debezium/transforms/SetBeforeAndAfterName.java
+++ b/src/main/java/com/inloco/debezium/transforms/SetBeforeAndAfterName.java
@@ -36,7 +36,7 @@ public class SetBeforeAndAfterName implements Transformation {
 
   @Override
   public ConnectRecord apply(ConnectRecord record) {
-    if(record == null) return record;
+    if (record == null) return record;
     Schema beforeSchema = record.valueSchema().field(BEFORE_FIELD_NAME).schema();
     Schema afterSchema = record.valueSchema().field(AFTER_FIELD_NAME).schema();
     if (beforeSchema == null || afterSchema == null) return record;

--- a/src/main/java/com/inloco/debezium/transforms/SetEventId.java
+++ b/src/main/java/com/inloco/debezium/transforms/SetEventId.java
@@ -34,6 +34,7 @@ public class SetEventId implements Transformation {
 
   @Override
   public ConnectRecord apply(ConnectRecord record) {
+    if(record == null) return record;
     final Struct recordValue = requireStruct(record.value(), PURPOSE);
     if (recordValue.schema().field(eventIdField) != null) return record;
     final Schema updatedRecordSchema = updateSchema(recordValue);

--- a/src/main/java/com/inloco/debezium/transforms/SetEventId.java
+++ b/src/main/java/com/inloco/debezium/transforms/SetEventId.java
@@ -34,7 +34,7 @@ public class SetEventId implements Transformation {
 
   @Override
   public ConnectRecord apply(ConnectRecord record) {
-    if(record == null) return record;
+    if (record == null) return record;
     final Struct recordValue = requireStruct(record.value(), PURPOSE);
     if (recordValue.schema().field(eventIdField) != null) return record;
     final Schema updatedRecordSchema = updateSchema(recordValue);

--- a/src/main/java/com/inloco/debezium/transforms/SetEventId.java
+++ b/src/main/java/com/inloco/debezium/transforms/SetEventId.java
@@ -34,7 +34,7 @@ public class SetEventId implements Transformation {
 
   @Override
   public ConnectRecord apply(ConnectRecord record) {
-    if (record == null) return record;
+    if (record == null || record.valueSchema() == null) return record;
     final Struct recordValue = requireStruct(record.value(), PURPOSE);
     if (recordValue.schema().field(eventIdField) != null) return record;
     final Schema updatedRecordSchema = updateSchema(recordValue);

--- a/src/test/java/com/inloco/debezium/transforms/SetBeforeAndAfterNameTest.java
+++ b/src/test/java/com/inloco/debezium/transforms/SetBeforeAndAfterNameTest.java
@@ -111,12 +111,43 @@ class SetBeforeAndAfterNameTest {
     assertThat(transformedRecord).isNull();
   }
 
+  @Test
+  void testSetBeforeAndAfterName_withInvalidSchema_shouldReturnSameRecord() {
+    Schema schema = createNamedSchemaWithAfterOnlySchema();
+    Struct value = populateInnerFields(schema, Collections.emptyList());
+    SinkRecord record = new SinkRecord("", 0, null, null, schema, value, 0);
+
+    String newName = "com.my.app.internal.Value";
+    Map<String, Object> configurations = new HashMap<>();
+    configurations.put(SetBeforeAndAfterName.NEW_NAME_CONFIG, newName);
+    SetBeforeAndAfterName transform = new SetBeforeAndAfterName();
+    transform.configure(configurations);
+
+    ConnectRecord transformedRecord = transform.apply(record);
+    assertThat(transformedRecord).isEqualTo(record);
+
+    schema = createNamedSchemaWithAfterOnlySchema();
+    value = populateInnerFields(schema, Collections.emptyList());
+    record = new SinkRecord("", 0, null, null, schema, value, 0);
+
+    transformedRecord = transform.apply(record);
+    assertThat(transformedRecord).isEqualTo(record);
+  }
+
   private Schema createValueSchema() {
     return SchemaBuilder.struct()
         .name(ROOT_LEVEL_NAME)
         .field("after", createInnerSchema())
         .field("before", createInnerSchema())
         .build();
+  }
+
+  private Schema createNamedSchemaWithBeforeOnlySchema() {
+    return SchemaBuilder.struct().name(ROOT_LEVEL_NAME).field("before", createInnerSchema()).build();
+  }
+
+  private Schema createNamedSchemaWithAfterOnlySchema() {
+    return SchemaBuilder.struct().name(ROOT_LEVEL_NAME).field("after", createInnerSchema()).build();
   }
 
   private Schema createInnerSchema() {

--- a/src/test/java/com/inloco/debezium/transforms/SetBeforeAndAfterNameTest.java
+++ b/src/test/java/com/inloco/debezium/transforms/SetBeforeAndAfterNameTest.java
@@ -20,7 +20,7 @@ class SetBeforeAndAfterNameTest {
   private static final String INNER_NAME_WITH_NAMESPACE = "db.namespace.table.Value";
 
   @Test
-  void testSetEventId_withAllConfigs() {
+  void testSetBeforeAndAfterName_withAllConfigs() {
     Schema schema = createValueSchema();
     Struct value = populateInnerFields(schema, Arrays.asList("before", "after"));
     SinkRecord record = new SinkRecord("", 0, null, null, schema, value, 0);
@@ -39,7 +39,7 @@ class SetBeforeAndAfterNameTest {
   }
 
   @Test
-  void testSetEventId_withoutBeforeEvent() {
+  void testSetBeforeAndAfterName_withoutBeforeEvent() {
     Schema schema = createValueSchema();
     Struct value = populateInnerFields(schema, Collections.singletonList("after"));
     SinkRecord record = new SinkRecord("", 0, null, null, schema, value, 0);
@@ -59,7 +59,7 @@ class SetBeforeAndAfterNameTest {
   }
 
   @Test
-  void testSetEventId_withoutAfterEvent() {
+  void testSetBeforeAndAfterName_withoutAfterEvent() {
     Schema schema = createValueSchema();
     Struct value = populateInnerFields(schema, Collections.singletonList("before"));
     SinkRecord record = new SinkRecord("", 0, null, null, schema, value, 0);
@@ -79,7 +79,7 @@ class SetBeforeAndAfterNameTest {
   }
 
   @Test
-  void testSetEventId_withDeleteEvent() {
+  void testSetBeforeAndAfterName_withDeleteEvent() {
     Schema schema = createValueSchema();
     Struct value = populateInnerFields(schema, Collections.emptyList());
     SinkRecord record = new SinkRecord("", 0, null, null, schema, value, 0);
@@ -97,6 +97,18 @@ class SetBeforeAndAfterNameTest {
     assertThat(transformedRecord.valueSchema().field("after")).isNotNull();
     assertThat(transformedRecord.valueSchema().field("after").schema().name()).isEqualTo(newName);
     assertThat(transformedRecordValue.schema().name()).isEqualTo(ROOT_LEVEL_NAME);
+  }
+
+  @Test
+  void testSetBeforeAndAfterName_withNullMessage() {
+    String newName = "com.my.app.internal.Value";
+    Map<String, Object> configurations = new HashMap<>();
+    configurations.put(SetBeforeAndAfterName.NEW_NAME_CONFIG, newName);
+    SetBeforeAndAfterName transform = new SetBeforeAndAfterName();
+    transform.configure(configurations);
+
+    ConnectRecord transformedRecord = transform.apply(null);
+    assertThat(transformedRecord).isNull();
   }
 
   private Schema createValueSchema() {

--- a/src/test/java/com/inloco/debezium/transforms/SetBeforeAndAfterNameTest.java
+++ b/src/test/java/com/inloco/debezium/transforms/SetBeforeAndAfterNameTest.java
@@ -143,7 +143,10 @@ class SetBeforeAndAfterNameTest {
   }
 
   private Schema createNamedSchemaWithBeforeOnlySchema() {
-    return SchemaBuilder.struct().name(ROOT_LEVEL_NAME).field("before", createInnerSchema()).build();
+    return SchemaBuilder.struct()
+        .name(ROOT_LEVEL_NAME)
+        .field("before", createInnerSchema())
+        .build();
   }
 
   private Schema createNamedSchemaWithAfterOnlySchema() {

--- a/src/test/java/com/inloco/debezium/transforms/SetEventIdTest.java
+++ b/src/test/java/com/inloco/debezium/transforms/SetEventIdTest.java
@@ -70,6 +70,20 @@ class SetEventIdTest {
             requireStruct(secondTransformedRecord.value(), "testing").getString(eventIdField));
   }
 
+  @Test
+  void testSetEvenetId_givenNullEvent_shouldReturnNull() {
+    String eventIdField = "event_id_test";
+    Map<String, Object> configurations = new HashMap<>();
+    configurations.put(SetEventId.EVENT_FIELD_CONFIG, eventIdField);
+    SetEventId transform = new SetEventId();
+    transform.configure(configurations);
+
+    ConnectRecord transformedRecord = transform.apply(null);
+
+    assertThat(transformedRecord).isNull();
+
+  }
+
   private Schema createValueSchema() {
     return SchemaBuilder.struct()
         .name("record")

--- a/src/test/java/com/inloco/debezium/transforms/SetEventIdTest.java
+++ b/src/test/java/com/inloco/debezium/transforms/SetEventIdTest.java
@@ -81,7 +81,6 @@ class SetEventIdTest {
     ConnectRecord transformedRecord = transform.apply(null);
 
     assertThat(transformedRecord).isNull();
-
   }
 
   private Schema createValueSchema() {


### PR DESCRIPTION
We had an issue using this SMT, the problem was that we had to setup heatbeat messages that didn't have the required schema for this SMT to work, so it was having nullpointer issues.
 With this changes the SMT should only return the record as is if the record doesn't have the expected schema.