### PR TITLE
Create custom converter for PostgreSQL text columns

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,33 +11,35 @@ For these to be used in a task, first the JAR should be generated:
 
 And then, it has to be copied to the Kafka Connect directory of the deployment.
 
-##  SetDebeziumRecordPartition
+## Transforms
+
+###  SetDebeziumRecordPartition
 
 This transform makes it so records that have the same given key field will
 always be in the same Kafka Partition. This is especially useful for cases
 when updates for the same entity has to be in the same partition.
 
-## SetTombstoneRecord
+### SetTombstoneRecord
 
 Tombstone (null-valued messages) are the only way to deleted old messages from
 Kafka. This transform makes it so that records that have the null value in a
 specified value field will produce null-valued messages.
 
-## PostgresDebeziumGeopointMapping
+### PostgresDebeziumGeopointMapping
 
 This transform receives a standard debezium record and transforms two Float/Double fields to
 a format that is accepted in ElasticSearch as geo_point(format="lat,lng").
 The user has to pass the name of the streamed database's latitude and longitude fields and
 also the name of the field he wants to output to.
 
-## SetEventId
+### SetEventId
 
 This transform adds a unique, UUID-generated field to represent a given event.
 Its goal is supporting the automatic generation of unique ids for cases where they are not available in Debezium's source
 and an outbox pattern is not being actively utilized. The name of the field may be passed as a configuration
 in the Debezium source properties as `field`. If the given name already exists, the SMT ignores the given record.
 
-## SetBeforeAndAfterName
+### SetBeforeAndAfterName
 
 This transform modifies the `namespace` and `name` fields for the `before` and `after` Debezium schemata.
 
@@ -49,3 +51,19 @@ This make it so the `before` and `after` namespaces are always set to the databa
 The transform's only configuration value is the new `name` for the schemata, which may be composed of a
 dot-separated string that will in turn be converted as a package-like structure to generate the namespace and name for the records,
 i.e. `com.my.app` turns into `{ "namespace": "com.my", "name": "app" }`.
+
+## Converters
+
+### PostgresDebeziumTextColumnConverter
+
+This converter maps `text[]` and `text[][]` columns from PostgreSQL tables to a bi-dimensional list of strings.
+
+To use it, place the `debezium-smts` JAR inside the PostgreSQL connector classpath, and then set it up on
+the connector configuration file:
+```
+        converters=text_column_converter
+        text_column_converter.type=com.inloco.debezium.converters.PostgresDebeziumTextColumnConverter
+        text_column_converter.column.list=firstcolumn,secondcolumn,thirdcolumn
+```
+
+The `column.list` field is an optional, comma-separated list of columns that will be converted.

--- a/build.gradle
+++ b/build.gradle
@@ -10,8 +10,13 @@ repositories {
 }
 
 dependencies {
+    annotationProcessor group: 'org.projectlombok', name: 'lombok', version: '1.18.24'
+    compileOnly group: 'org.projectlombok', name: 'lombok', version: '1.18.24'
+
     implementation group: 'org.apache.kafka', name: 'connect-transforms', version: '0.10.2.1'
     implementation group: 'org.apache.commons', name: 'commons-lang3', version: '3.5'
+    implementation group: 'io.debezium', name: 'debezium-api', version: '1.9.2.Final'
+    implementation group: 'org.postgresql', name: 'postgresql', version: '42.3.6'
 
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.4.2'
     testImplementation 'org.assertj:assertj-core:3.10.0'

--- a/src/main/java/com/inloco/debezium/converters/PostgresDebeziumTextColumnConverter.java
+++ b/src/main/java/com/inloco/debezium/converters/PostgresDebeziumTextColumnConverter.java
@@ -1,0 +1,82 @@
+package com.inloco.debezium.converters;
+
+import io.debezium.spi.converter.CustomConverter;
+import io.debezium.spi.converter.RelationalColumn;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Properties;
+import java.util.Set;
+import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.postgresql.jdbc.PgArray;
+
+@Slf4j
+public class PostgresDebeziumTextColumnConverter
+    implements CustomConverter<SchemaBuilder, RelationalColumn> {
+  private static final String TEXT_COLUMN_TYPE_NAME = "_text";
+  private static final String COLUMN_NAME_PROPERTY = "column.list";
+  private static final String COLUMN_NAME_PROPERTY_SEPARATOR = ",";
+
+  private SchemaBuilder fieldSchema;
+  private Set<String> columnList;
+
+  @Override
+  public void configure(Properties props) {
+    fieldSchema = SchemaBuilder.array(SchemaBuilder.array(Schema.STRING_SCHEMA));
+    columnList = parseColumnList(props.getProperty(COLUMN_NAME_PROPERTY));
+  }
+
+  @Override
+  public void converterFor(
+      RelationalColumn column, ConverterRegistration<SchemaBuilder> registration) {
+    if (columnList.contains(column.name())) {
+      if (column.typeName().equals(TEXT_COLUMN_TYPE_NAME)) {
+        registration.register(fieldSchema, columnValue -> mapToList((PgArray) columnValue));
+      } else {
+        log.warn(
+            "Skipping mapping of column \""
+                + column.name()
+                + "\" of type \""
+                + column.typeName()
+                + "\", which does not match expected type \""
+                + TEXT_COLUMN_TYPE_NAME
+                + "\".");
+      }
+    }
+  }
+
+  private Set<String> parseColumnList(String columnListProp) {
+    if (columnListProp == null) {
+      return Collections.emptySet();
+    }
+    return new HashSet<>(Arrays.asList(columnListProp.split(COLUMN_NAME_PROPERTY_SEPARATOR)));
+  }
+
+  private List<List<String>> mapToList(PgArray columnValue) {
+    try {
+      Object columnValueObj = columnValue.getArray();
+      if (columnValueObj instanceof String[]) {
+        return List.of(map1DArray((String[]) columnValueObj));
+      } else if (columnValueObj instanceof String[][]) {
+        return map2DArray((String[][]) columnValueObj);
+      }
+      log.error("Unknown type for the column value object");
+      return null;
+    } catch (Exception e) {
+      log.error(e.toString());
+      return null;
+    }
+  }
+
+  private List<List<String>> map2DArray(String[][] array) {
+    return Arrays.stream(array).map(this::map1DArray).collect(Collectors.toList());
+  }
+
+  private List<String> map1DArray(String[] array) {
+    return Arrays.asList(array);
+  }
+}


### PR DESCRIPTION
# Context

Recently, we have added a new field in our database that is represented as a matrix of strings (`text[][]`). Since then, we have had some issues because of the way Debezium converts this field to our Kafka schema.

Initially, we noticed that, despite declaring the column as `text[2][]` in the migration, when accessing the database and running `\d table`, the column was declared as `text[]`. A little odd, but no big deal.

We then declared this field in our Avro schema as a bi-dimensional array of strings (`String[][]`). It didn't work: Debezium tried to register the schema with a one-dimensional array. So we decided to go with the 1D array (`String[]`).

Everything worked, but when we actually saw the conversion that Debezium made, we were receiving a string that was a reference to a Java object, not our expected values, e.g. instead of returning something like `[["some", "value"]]`, Debezium returned `["[Ljava.lang.String;@4dbc8e7c"]`.

After some investigation, we found out that the way to solve this issue was to implement a custom converter, since Debezium was unable to convert the type we had properly. 

# Proposed changes

This PR introduces a converter that receives a comma-separated list of columns and maps their values from `text[]` or `text[][]` to a bi-dimensional list of strings.

Further descriptions on how to use this converter can be found in the updated `README`.