### PR TITLE
Map empty 1D arrays to empty 2D arrays instead of a 2D array with one empty entry

### DIFF
--- a/src/main/java/com/inloco/debezium/converters/PostgresDebeziumTextColumnConverter.java
+++ b/src/main/java/com/inloco/debezium/converters/PostgresDebeziumTextColumnConverter.java
@@ -60,7 +60,8 @@ public class PostgresDebeziumTextColumnConverter
     try {
       Object columnValueObj = columnValue.getArray();
       if (columnValueObj instanceof String[]) {
-        return List.of(map1DArray((String[]) columnValueObj));
+        List<String> mappedArray = map1DArray((String[]) columnValueObj);
+        return mappedArray.isEmpty() ? List.of() : List.of(mappedArray);
       } else if (columnValueObj instanceof String[][]) {
         return map2DArray((String[][]) columnValueObj);
       }


### PR DESCRIPTION
# Context

If Debezium received `[]` (default empty array for `text[]` columns), the `columnValue` would be an empty 1D array. Therefore, the following code section:
```java
return List.of(map1DArray((String[]) columnValueObj));
``` 

Would convert `[]` to `[[]]`, which is not accurate.

# Proposed changes

Only encapsulate the mapped 1D array if it is not empty.